### PR TITLE
Fix hashing of null values

### DIFF
--- a/src/haystack/val/value.rs
+++ b/src/haystack/val/value.rs
@@ -63,9 +63,10 @@ use std::hash::Hash;
 /// assert_eq!(Grid::try_from(&grid).unwrap().len(), 2);
 /// ```
 ///
-#[derive(PartialOrd, Eq, Ord, Clone, Debug)]
+#[derive(PartialOrd, Eq, Ord, Clone, Debug, Default)]
 pub enum Value {
     /// No value
+    #[default]
     Null,
     /// A remove tag
     Remove,
@@ -352,13 +353,6 @@ impl Value {
     }
 }
 
-/// Implements the `Default` trait for the `Value`
-impl Default for Value {
-    fn default() -> Self {
-        Value::Null
-    }
-}
-
 /// Implement user friendly display for a [Value](crate::val::Value)
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -397,7 +391,7 @@ impl Display for Value {
 impl Hash for Value {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
-            Value::Null => Self::Null.hash(state),
+            Value::Null => std::any::TypeId::of::<Value>().hash(state),
 
             Value::Marker => super::marker::Marker.hash(state),
             Value::Remove => super::remove::Remove.hash(state),

--- a/tests/values/test_value.rs
+++ b/tests/values/test_value.rs
@@ -2,6 +2,8 @@
 
 //! Test haystack types
 
+use std::collections::HashSet;
+
 use libhaystack::units::get_unit_or_default;
 
 #[cfg(test)]
@@ -13,6 +15,19 @@ fn test_value_null() {
     let value = Value::default();
     assert!(value.is_null());
     assert!(!value.is_number());
+
+    let mut set = HashSet::<Value>::new();
+    set.insert(value);
+}
+
+#[test]
+fn test_value_null_hash() {
+    let value = Value::default();
+
+    let mut set = HashSet::<Value>::new();
+    set.insert(value);
+
+    assert!(set.contains(&Value::Null))
 }
 
 #[test]


### PR DESCRIPTION
Use the type id of the Value type as the base for the hashing of a Null Value variant, which is the default value for a Value Type.

See https://github.com/j2inn/libhaystack/issues/12