### PR TITLE
fix infinite loop for zinc parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libhaystack"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libhaystack"
-version = "3.1.0"
+version = "3.1.1"
 description = "Rust implementation of the Haystack 4 data types, defs, filter, units, and encodings"
 authors = ["J2 Innovations", "Radu Racariu <radur@j2inn.com>"]
 edition = "2024"

--- a/src/bin/dict_rss_compare.rs
+++ b/src/bin/dict_rss_compare.rs
@@ -6,269 +6,281 @@
 //! cargo run --release --bin dict_rss_compare
 
 #[cfg(not(target_os = "linux"))]
-compile_error!("dict_rss_compare is Linux-only (requires /proc/self/status)");
-
-use libhaystack::dict;
-use libhaystack::val::*;
-use std::env;
-use std::fs;
-use std::process::Command;
-
-const DICT_COUNT: usize = 100_000;
-const DICT_ENTRY_COUNT: usize = 32;
-const CHILD_MARKER: &str = "RSS_RESULT";
-const MODE_ARG: &str = "--mode";
-
-#[derive(Clone, Copy)]
-enum RssMode {
-    Vec32,
-    Tree0,
-}
-
-impl RssMode {
-    fn from_str(input: &str) -> Option<Self> {
-        match input {
-            "vec32" => Some(Self::Vec32),
-            "tree0" => Some(Self::Tree0),
-            _ => None,
-        }
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Vec32 => "vec32",
-            Self::Tree0 => "tree0",
-        }
-    }
-
-    fn small_max_entries(self) -> usize {
-        match self {
-            Self::Vec32 => 32,
-            Self::Tree0 => 0,
-        }
-    }
-}
-
 fn main() {
-    if let Some(mode) = mode_from_args() {
-        run_child(mode);
-        return;
-    }
-
-    let vec32_delta_kb = run_mode_subprocess(RssMode::Vec32);
-    let tree0_delta_kb = run_mode_subprocess(RssMode::Tree0);
-
-    let winner = if vec32_delta_kb < tree0_delta_kb {
-        "vec32"
-    } else if tree0_delta_kb < vec32_delta_kb {
-        "tree0"
-    } else {
-        "tie"
-    };
-
-    let vec_vs_tree_pct = if tree0_delta_kb > 0 {
-        (tree0_delta_kb as f64 - vec32_delta_kb as f64) * 100.0 / tree0_delta_kb as f64
-    } else {
-        0.0
-    };
-
-    println!(
-        "RSS_COMPARE dicts={} entries={} vec32_delta_kb={} tree0_delta_kb={} winner={} vec_vs_tree_pct={:.2}",
-        DICT_COUNT, DICT_ENTRY_COUNT, vec32_delta_kb, tree0_delta_kb, winner, vec_vs_tree_pct
-    );
+    eprintln!("dict_rss_compare is Linux-only (requires /proc/self/status)");
+    std::process::exit(1);
 }
 
-fn mode_from_args() -> Option<RssMode> {
-    let mut args = env::args().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == MODE_ARG {
-            let value = args.next()?;
-            return RssMode::from_str(&value);
+#[cfg(target_os = "linux")]
+mod linux {
+    use libhaystack::dict;
+    use libhaystack::val::*;
+    use std::env;
+    use std::fs;
+    use std::process::Command;
+
+    const DICT_COUNT: usize = 100_000;
+    const DICT_ENTRY_COUNT: usize = 32;
+    const CHILD_MARKER: &str = "RSS_RESULT";
+    const MODE_ARG: &str = "--mode";
+
+    #[derive(Clone, Copy)]
+    enum RssMode {
+        Vec32,
+        Tree0,
+    }
+
+    impl RssMode {
+        fn from_str(input: &str) -> Option<Self> {
+            match input {
+                "vec32" => Some(Self::Vec32),
+                "tree0" => Some(Self::Tree0),
+                _ => None,
+            }
         }
-    }
-    None
-}
 
-fn run_mode_subprocess(mode: RssMode) -> u64 {
-    let exe = env::current_exe().expect("current executable path");
-    let output = Command::new(exe)
-        .arg(MODE_ARG)
-        .arg(mode.as_str())
-        .output()
-        .expect("spawn child process");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    if !output.status.success() {
-        panic!(
-            "child mode {} failed\nstdout:\n{}\nstderr:\n{}",
-            mode.as_str(),
-            stdout,
-            stderr
-        );
-    }
-
-    parse_child_delta_kb(&stdout)
-        .or_else(|| parse_child_delta_kb(&stderr))
-        .unwrap_or_else(|| {
-            panic!(
-                "missing RSS marker for mode {}\nstdout:\n{}\nstderr:\n{}",
-                mode.as_str(),
-                stdout,
-                stderr
-            )
-        })
-}
-
-fn parse_child_delta_kb(output: &str) -> Option<u64> {
-    for line in output.lines() {
-        if !line.contains(CHILD_MARKER) {
-            continue;
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::Vec32 => "vec32",
+                Self::Tree0 => "tree0",
+            }
         }
-        for part in line.split_whitespace() {
-            if let Some(value) = part.strip_prefix("delta_kb=")
-                && let Ok(parsed) = value.parse::<u64>()
-            {
-                return Some(parsed);
+
+        fn small_max_entries(self) -> usize {
+            match self {
+                Self::Vec32 => 32,
+                Self::Tree0 => 0,
             }
         }
     }
-    None
-}
 
-fn run_child(mode: RssMode) {
-    let before_kb = current_rss_kb();
-    let dicts = build_dicts(mode);
-    let after_kb = current_rss_kb();
-
-    let checksum: usize = dicts.iter().map(|d| d.len()).sum();
-    assert_eq!(checksum, DICT_COUNT * DICT_ENTRY_COUNT);
-
-    let delta_kb = after_kb.saturating_sub(before_kb);
-    println!(
-        "{} mode={} before_kb={} after_kb={} delta_kb={}",
-        CHILD_MARKER,
-        mode.as_str(),
-        before_kb,
-        after_kb,
-        delta_kb
-    );
-
-    std::hint::black_box(dicts);
-}
-
-fn build_dicts(mode: RssMode) -> Vec<Dict> {
-    let mut dicts = Vec::with_capacity(DICT_COUNT);
-    for i in 0..DICT_COUNT {
-        let mut dict = Dict::with_small_max_entries(mode.small_max_entries());
-        for (key, value) in make_entries(i) {
-            dict.insert(key, value);
+    pub fn run() {
+        if let Some(mode) = mode_from_args() {
+            run_child(mode);
+            return;
         }
-        dicts.push(dict);
+
+        let vec32_delta_kb = run_mode_subprocess(RssMode::Vec32);
+        let tree0_delta_kb = run_mode_subprocess(RssMode::Tree0);
+
+        let winner = if vec32_delta_kb < tree0_delta_kb {
+            "vec32"
+        } else if tree0_delta_kb < vec32_delta_kb {
+            "tree0"
+        } else {
+            "tie"
+        };
+
+        let vec_vs_tree_pct = if tree0_delta_kb > 0 {
+            (tree0_delta_kb as f64 - vec32_delta_kb as f64) * 100.0 / tree0_delta_kb as f64
+        } else {
+            0.0
+        };
+
+        println!(
+            "RSS_COMPARE dicts={} entries={} vec32_delta_kb={} tree0_delta_kb={} winner={} vec_vs_tree_pct={:.2}",
+            DICT_COUNT, DICT_ENTRY_COUNT, vec32_delta_kb, tree0_delta_kb, winner, vec_vs_tree_pct
+        );
     }
-    dicts
-}
 
-fn make_entries(seed: usize) -> Vec<(String, Value)> {
-    let date = Date::from_ymd(2024, ((seed % 12) + 1) as u32, ((seed % 28) + 1) as u32)
-        .expect("valid date");
-    let time = Time::from_hms_milli(
-        (seed % 24) as u32,
-        (seed % 60) as u32,
-        ((seed * 7) % 60) as u32,
-        ((seed * 13) % 1000) as u32,
-    )
-    .expect("valid time");
-    let datetime = DateTime::parse_from_rfc3339("2024-06-19T19:48:23Z").expect("valid datetime");
-
-    let list_value = Value::List(vec![
-        Value::from(seed as i32),
-        Value::make_marker(),
-        Value::from("l"),
-    ]);
-    let inner_dict = dict! {
-        "innerBool" => seed.is_multiple_of(2),
-        "innerNum" => (seed % 1000) as i32,
-        "innerStr" => format!("inner-{seed}")
-    };
-    let grid_value = Value::make_grid_from_dicts(vec![
-        dict! {
-            "id" => Value::make_ref(&format!("r:{seed}")),
-            "val" => (seed % 100) as i32,
-        },
-        dict! {
-            "id" => Value::make_ref(&format!("r:{}", seed + 1)),
-            "val" => ((seed + 1) % 100) as i32,
-        },
-    ]);
-
-    vec![
-        ("k00".into(), Value::Null),
-        ("k01".into(), Value::make_marker()),
-        ("k02".into(), Value::make_remove()),
-        ("k03".into(), Value::make_na()),
-        ("k04".into(), Value::from(seed.is_multiple_of(2))),
-        ("k05".into(), Value::from(seed as i32)),
-        ("k06".into(), Value::from((seed as f64) * 1.5)),
-        ("k07".into(), Value::from(format!("str-{seed}"))),
-        ("k08".into(), Value::make_uri(&format!("/p/{seed}"))),
-        ("k09".into(), Value::make_ref(&format!("ref:{seed}"))),
-        ("k10".into(), Value::make_symbol(&format!("sym{seed}"))),
-        ("k11".into(), Value::make_date(date)),
-        ("k12".into(), Value::make_time(time)),
-        ("k13".into(), Value::make_datetime(datetime)),
-        (
-            "k14".into(),
-            Value::make_coord_from(37.0 + seed as f64 / 1000.0, -122.0),
-        ),
-        (
-            "k15".into(),
-            Value::make_xstr_from("TypeA", &format!("x-{seed}")),
-        ),
-        ("k16".into(), list_value),
-        ("k17".into(), Value::make_dict(inner_dict)),
-        ("k18".into(), grid_value),
-        (
-            "k19".into(),
-            Value::from(format!("long-value-{seed}-abcdefg")),
-        ),
-        ("k20".into(), Value::from(((seed % 10_000) as i32) - 5000)),
-        ("k21".into(), Value::make_false()),
-        ("k22".into(), Value::make_datetime(datetime)),
-        ("k23".into(), Value::List(vec![])),
-        ("k24".into(), Value::make_dict(Dict::new())),
-        ("k25".into(), Value::make_grid(Grid::make_empty())),
-        (
-            "k26".into(),
-            Value::make_ref_with_dis(&format!("refdis:{seed}"), &format!("Ref {seed}")),
-        ),
-        ("k27".into(), Value::make_uri("/static/path")),
-        ("k28".into(), Value::make_symbol("equip")),
-        (
-            "k29".into(),
-            Value::make_coord_from(51.5, -0.1 - seed as f64 / 10_000.0),
-        ),
-        (
-            "k30".into(),
-            Value::make_xstr_from("TypeB", &format!("payload-{seed}")),
-        ),
-        ("k31".into(), Value::from(((seed % 1_000_000) as i32) * 3)),
-    ]
-}
-
-fn current_rss_kb() -> u64 {
-    let status = fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
-    for line in status.lines() {
-        if let Some(rest) = line.strip_prefix("VmRSS:") {
-            let value = rest
-                .split_whitespace()
-                .next()
-                .expect("VmRSS value")
-                .parse::<u64>()
-                .expect("VmRSS parse");
-            return value;
+    fn mode_from_args() -> Option<RssMode> {
+        let mut args = env::args().skip(1);
+        while let Some(arg) = args.next() {
+            if arg == MODE_ARG {
+                let value = args.next()?;
+                return RssMode::from_str(&value);
+            }
         }
+        None
     }
-    panic!("VmRSS not found in /proc/self/status");
+
+    fn run_mode_subprocess(mode: RssMode) -> u64 {
+        let exe = env::current_exe().expect("current executable path");
+        let output = Command::new(exe)
+            .arg(MODE_ARG)
+            .arg(mode.as_str())
+            .output()
+            .expect("spawn child process");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if !output.status.success() {
+            panic!(
+                "child mode {} failed\nstdout:\n{}\nstderr:\n{}",
+                mode.as_str(),
+                stdout,
+                stderr
+            );
+        }
+
+        parse_child_delta_kb(&stdout)
+            .or_else(|| parse_child_delta_kb(&stderr))
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing RSS marker for mode {}\nstdout:\n{}\nstderr:\n{}",
+                    mode.as_str(),
+                    stdout,
+                    stderr
+                )
+            })
+    }
+
+    fn parse_child_delta_kb(output: &str) -> Option<u64> {
+        for line in output.lines() {
+            if !line.contains(CHILD_MARKER) {
+                continue;
+            }
+            for part in line.split_whitespace() {
+                if let Some(value) = part.strip_prefix("delta_kb=")
+                    && let Ok(parsed) = value.parse::<u64>()
+                {
+                    return Some(parsed);
+                }
+            }
+        }
+        None
+    }
+
+    fn run_child(mode: RssMode) {
+        let before_kb = current_rss_kb();
+        let dicts = build_dicts(mode);
+        let after_kb = current_rss_kb();
+
+        let checksum: usize = dicts.iter().map(|d| d.len()).sum();
+        assert_eq!(checksum, DICT_COUNT * DICT_ENTRY_COUNT);
+
+        let delta_kb = after_kb.saturating_sub(before_kb);
+        println!(
+            "{} mode={} before_kb={} after_kb={} delta_kb={}",
+            CHILD_MARKER,
+            mode.as_str(),
+            before_kb,
+            after_kb,
+            delta_kb
+        );
+
+        std::hint::black_box(dicts);
+    }
+
+    fn build_dicts(mode: RssMode) -> Vec<Dict> {
+        let mut dicts = Vec::with_capacity(DICT_COUNT);
+        for i in 0..DICT_COUNT {
+            let mut dict = Dict::with_small_max_entries(mode.small_max_entries());
+            for (key, value) in make_entries(i) {
+                dict.insert(key, value);
+            }
+            dicts.push(dict);
+        }
+        dicts
+    }
+
+    fn make_entries(seed: usize) -> Vec<(String, Value)> {
+        let date = Date::from_ymd(2024, ((seed % 12) + 1) as u32, ((seed % 28) + 1) as u32)
+            .expect("valid date");
+        let time = Time::from_hms_milli(
+            (seed % 24) as u32,
+            (seed % 60) as u32,
+            ((seed * 7) % 60) as u32,
+            ((seed * 13) % 1000) as u32,
+        )
+        .expect("valid time");
+        let datetime =
+            DateTime::parse_from_rfc3339("2024-06-19T19:48:23Z").expect("valid datetime");
+
+        let list_value = Value::List(vec![
+            Value::from(seed as i32),
+            Value::make_marker(),
+            Value::from("l"),
+        ]);
+        let inner_dict = dict! {
+            "innerBool" => seed.is_multiple_of(2),
+            "innerNum" => (seed % 1000) as i32,
+            "innerStr" => format!("inner-{seed}")
+        };
+        let grid_value = Value::make_grid_from_dicts(vec![
+            dict! {
+                "id" => Value::make_ref(&format!("r:{seed}")),
+                "val" => (seed % 100) as i32,
+            },
+            dict! {
+                "id" => Value::make_ref(&format!("r:{}", seed + 1)),
+                "val" => ((seed + 1) % 100) as i32,
+            },
+        ]);
+
+        vec![
+            ("k00".into(), Value::Null),
+            ("k01".into(), Value::make_marker()),
+            ("k02".into(), Value::make_remove()),
+            ("k03".into(), Value::make_na()),
+            ("k04".into(), Value::from(seed.is_multiple_of(2))),
+            ("k05".into(), Value::from(seed as i32)),
+            ("k06".into(), Value::from((seed as f64) * 1.5)),
+            ("k07".into(), Value::from(format!("str-{seed}"))),
+            ("k08".into(), Value::make_uri(&format!("/p/{seed}"))),
+            ("k09".into(), Value::make_ref(&format!("ref:{seed}"))),
+            ("k10".into(), Value::make_symbol(&format!("sym{seed}"))),
+            ("k11".into(), Value::make_date(date)),
+            ("k12".into(), Value::make_time(time)),
+            ("k13".into(), Value::make_datetime(datetime)),
+            (
+                "k14".into(),
+                Value::make_coord_from(37.0 + seed as f64 / 1000.0, -122.0),
+            ),
+            (
+                "k15".into(),
+                Value::make_xstr_from("TypeA", &format!("x-{seed}")),
+            ),
+            ("k16".into(), list_value),
+            ("k17".into(), Value::make_dict(inner_dict)),
+            ("k18".into(), grid_value),
+            (
+                "k19".into(),
+                Value::from(format!("long-value-{seed}-abcdefg")),
+            ),
+            ("k20".into(), Value::from(((seed % 10_000) as i32) - 5000)),
+            ("k21".into(), Value::make_false()),
+            ("k22".into(), Value::make_datetime(datetime)),
+            ("k23".into(), Value::List(vec![])),
+            ("k24".into(), Value::make_dict(Dict::new())),
+            ("k25".into(), Value::make_grid(Grid::make_empty())),
+            (
+                "k26".into(),
+                Value::make_ref_with_dis(&format!("refdis:{seed}"), &format!("Ref {seed}")),
+            ),
+            ("k27".into(), Value::make_uri("/static/path")),
+            ("k28".into(), Value::make_symbol("equip")),
+            (
+                "k29".into(),
+                Value::make_coord_from(51.5, -0.1 - seed as f64 / 10_000.0),
+            ),
+            (
+                "k30".into(),
+                Value::make_xstr_from("TypeB", &format!("payload-{seed}")),
+            ),
+            ("k31".into(), Value::from(((seed % 1_000_000) as i32) * 3)),
+        ]
+    }
+
+    fn current_rss_kb() -> u64 {
+        let status = fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let value = rest
+                    .split_whitespace()
+                    .next()
+                    .expect("VmRSS value")
+                    .parse::<u64>()
+                    .expect("VmRSS parse");
+                return value;
+            }
+        }
+        panic!("VmRSS not found in /proc/self/status");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    linux::run();
 }

--- a/src/haystack/encoding/zinc/decode/complex/grid.rs
+++ b/src/haystack/encoding/zinc/decode/complex/grid.rs
@@ -167,17 +167,18 @@ fn parse_grid_columns<'a, 'b: 'a, R: Read>(
         } else {
             match parse_grid_column_meta(parser) {
                 Ok(dict) => {
-                    if !dict.is_empty() {
-                        list.push(Column {
-                            name: name.to_string(),
-                            meta: Some(dict),
-                        });
+                    list.push(Column {
+                        name: name.to_string(),
+                        meta: if dict.is_empty() { None } else { Some(dict) },
+                    });
 
-                        if !parser.lexer.is_eof() {
-                            parser.lexer.expect_char(b',', "Grid columns")?;
-                        } else {
-                            break;
-                        }
+                    if parser.lexer.is_char(b'\n') {
+                        done = true;
+                        break;
+                    } else if !parser.lexer.is_eof() {
+                        parser.lexer.expect_char(b',', "Grid columns")?;
+                    } else {
+                        break;
                     }
                 }
                 Err(err) => {
@@ -272,6 +273,13 @@ impl<'a, 'b: 'a, R: Read> RowParser<'a, 'b, R> {
             if self.parser.lexer.cur.value.is_none() {
                 row_terminated = true;
                 break;
+            }
+
+            if col_num >= cols.len() {
+                return self.parser.lexer.make_generic_err(&format!(
+                    "Zinc Grid parser: Row has more values than columns (expected {}).",
+                    cols.len()
+                ));
             }
 
             let val = self.parser.parse_value()?;
@@ -598,5 +606,48 @@ mod test {
         let grid = result.unwrap();
         assert_eq!(grid.rows.len(), 1);
         assert_eq!(grid.rows[0]["b"], Value::make_number(42.0));
+    }
+
+    /// Regression test: a row with more values than declared columns should return
+    /// a descriptive error rather than panicking with an index-out-of-bounds.
+    #[test]
+    fn test_zinc_parse_grid_row_too_many_values_returns_error() {
+        let zinc = concat!(
+            "ver:\"3.0\"\n",
+            "a,b\n",
+            "1,2,3\n", // 3 values but only 2 columns declared
+        );
+
+        let mut input = Cursor::new(zinc.as_bytes());
+        let mut parser = Parser::make(&mut input).expect("Parser");
+
+        let result = parse_grid(&mut parser);
+        assert!(
+            result.is_err(),
+            "Expected error for row with more values than columns"
+        );
+    }
+
+    /// Regression test: a column row whose last column carries metadata and is
+    /// terminated by `\n` (no trailing comma) should parse successfully.
+    #[test]
+    fn test_zinc_parse_grid_columns_last_col_with_meta() {
+        let mut input = Cursor::new("\nsite,point dis:\"label\"\n".as_bytes());
+        let mut parser = Parser::make(&mut input).expect("Parser");
+
+        let cols = parse_grid_columns(&mut parser);
+        assert_eq!(
+            cols.ok(),
+            Some(vec![
+                Column {
+                    name: String::from("site"),
+                    meta: None,
+                },
+                Column {
+                    name: String::from("point"),
+                    meta: Some(dict! {"dis" => Value::make_str("label")}),
+                },
+            ])
+        );
     }
 }

--- a/src/haystack/encoding/zinc/decode/complex/grid.rs
+++ b/src/haystack/encoding/zinc/decode/complex/grid.rs
@@ -262,6 +262,18 @@ impl<'a, 'b: 'a, R: Read> RowParser<'a, 'b, R> {
                 break;
             }
 
+            // Treat an empty/exhausted lexer token as an implicit row terminator
+            // so that a trailing newline is not required on the last row.
+            // We specifically check `.value.is_none()` (the token is exhausted)
+            // rather than `is_eof()` (the byte stream is exhausted) because a
+            // number parsed right at EOF leaves `scanner.is_eof = true` while
+            // the number token is still in `lexer.cur` and must be consumed
+            // before the row can end.
+            if self.parser.lexer.cur.value.is_none() {
+                row_terminated = true;
+                break;
+            }
+
             let val = self.parser.parse_value()?;
             dict.insert(cols[col_num].name.clone(), val);
 
@@ -525,5 +537,66 @@ mod test {
             Grid::try_from(&grid.rows[0]["val"]).expect("Grid").len(),
             14
         )
+    }
+
+    /// Regression test: parsing a Zinc grid whose string cells contain `\$` escape sequences
+    /// (used in Haystack filter expressions). This previously caused an infinite loop.
+    #[test]
+    fn test_zinc_parse_grid_with_dollar_escape_in_string() {
+        let zinc = concat!(
+            "ver:\"3.0\"\n",
+            "binding,bundle,display,kind,name,readTag,writable,writeLevel\n",
+            "\"equipRef==\\$id and navName==\\\"CO_Alarm\\\"\",",
+            ",\"CO_Alarm\",\"Bool\",\"co_Alarm\",\"curVal\",\"\u{2713}\",14\n",
+            "\"equipRef==\\$id and sensor\",",
+            ",\"CO_Level\",\"Number\",\"co_Level\",\"curVal\",\"\u{2713}\",14\n",
+        );
+
+        let mut input = Cursor::new(zinc.as_bytes());
+        let mut parser = Parser::make(&mut input).expect("Parser");
+
+        let grid = parse_grid(&mut parser);
+        assert!(
+            grid.is_ok(),
+            "Should parse grid with \\$ escapes: {err:?}",
+            err = grid.map_err(|e| e.to_string())
+        );
+
+        let grid = grid.unwrap();
+        assert_eq!(grid.rows.len(), 2);
+        assert_eq!(
+            grid.rows[0]["binding"],
+            Value::make_str("equipRef==$id and navName==\"CO_Alarm\"")
+        );
+        assert_eq!(grid.rows[0]["writeLevel"], Value::make_number(14.0));
+        assert_eq!(grid.rows[1]["kind"], Value::make_str("Number"));
+    }
+
+    /// Regression test: a Zinc grid whose last row ends without a trailing newline should
+    /// complete successfully (forgiving behaviour) rather than looping forever.
+    #[test]
+    fn test_zinc_parse_grid_unterminated_last_row_returns_error() {
+        // No trailing '\n' after the last row value.
+        let zinc = concat!(
+            "ver:\"3.0\"\n",
+            "a,b\n",
+            "\"foo\",42", // deliberately omit the trailing '\n'
+        );
+
+        let mut input = Cursor::new(zinc.as_bytes());
+        let mut parser = Parser::make(&mut input).expect("Parser");
+
+        // With the EOF-as-row-terminator fix the parser succeeds rather than
+        // hanging forever.  A missing trailing newline on the last row is
+        // treated as an implicit row termination.
+        let result = parse_grid(&mut parser);
+        assert!(
+            result.is_ok(),
+            "Expected success for EOF-terminated last row, got: {:?}",
+            result.err()
+        );
+        let grid = result.unwrap();
+        assert_eq!(grid.rows.len(), 1);
+        assert_eq!(grid.rows[0]["b"], Value::make_number(42.0));
     }
 }

--- a/src/haystack/encoding/zinc/decode/scalar/number.rs
+++ b/src/haystack/encoding/zinc/decode/scalar/number.rs
@@ -104,7 +104,7 @@ pub(crate) fn parse_neg_inf<R: Read>(scanner: &mut Scanner<R>) -> Result<Number,
 }
 
 fn is_unit_char<R: Read>(scanner: &mut Scanner<R>) -> bool {
-    scanner.is_alpha() || scanner.is_any_of("$/%_") || scanner.cur > 128
+    scanner.is_alpha() || scanner.is_any_of("$/%_") || scanner.cur >= 128
 }
 
 #[cfg(test)]

--- a/src/haystack/encoding/zinc/decode/scalar/str.rs
+++ b/src/haystack/encoding/zinc/decode/scalar/str.rs
@@ -43,8 +43,8 @@ pub(super) fn parse_str_escape<R: Read>(scanner: &mut Scanner<R>) -> Result<Stri
     scanner.read()?;
 
     match scanner.cur {
-        b'b' => Ok("\x0b".into()),
-        b'f' => Ok("\x0f".into()),
+        b'b' => Ok("\x08".into()),
+        b'f' => Ok("\x0c".into()),
         b'n' => Ok("\n".into()),
         b'r' => Ok("\r".into()),
         b't' => Ok("\t".into()),
@@ -135,5 +135,15 @@ mod test {
             let str = parse_str(&mut scanner);
             assert!(str.is_err())
         }
+    }
+
+    #[test]
+    fn test_zinc_parse_str_backspace_and_formfeed_escapes() {
+        // \b must decode to backspace (U+0008), \f to form feed (U+000C)
+        let mut input = Cursor::new("\"\\b\\f\"".as_bytes());
+        let mut scanner = super::Scanner::make(&mut input).expect("Scanner");
+
+        let str = parse_str(&mut scanner);
+        assert_eq!(str.ok(), Some(Str::make("\x08\x0c")));
     }
 }


### PR DESCRIPTION
Zinc parsing: bug fixes from code review

- Fix incorrect \b and \f string escape byte values
- Fix panic on row with more values than columns
- Fix parse failure when last grid column has metadata
- Fix column silently dropped when metadata parse returns empty dict
- Fix is_unit_char off-by-one excluding leading UTF-8 byte 0x80
- Fixed dict rss compare for non-linux systems